### PR TITLE
Use unique query for each waterfall requests

### DIFF
--- a/pages/api/xata-global.ts
+++ b/pages/api/xata-global.ts
@@ -46,6 +46,9 @@ export default async function api(req: Request) {
   for (let i = 0; i < count; i++) {
     data = await xata.db.employees
       .select(["emp_no", "first_name", "last_name"])
+      .filter({
+        last_name: {$startsWith: String.fromCharCode(65 + i)}
+      })
       .getMany({ pagination: { size: 10 }, consistency: "eventual" });
   }
 


### PR DESCRIPTION
The application is meant to provide realistic latency measurement in various configuration. However, the queries are exactly the same between each waterfall request, which allows some implementations to simply cache the result in memory and have the exact same latency for 1 and 5 waterfall request.

To address this, I have added a filter by first letter in the last name. This results in different query for each waterfall requests and thus a more realistic user workload.

The same thing must be done for all other implementations.